### PR TITLE
Clef permettant de récupérer le ticket n'est plus forcément return.

### DIFF
--- a/src/main/java/org/esupportail/cas/audit/AgimusServicesAuditTrailManager.java
+++ b/src/main/java/org/esupportail/cas/audit/AgimusServicesAuditTrailManager.java
@@ -1,6 +1,7 @@
 package org.esupportail.cas.audit;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -51,8 +52,19 @@ public class AgimusServicesAuditTrailManager implements AuditTrailManager {
     		Map<String,String> resourceOperatedUponMap = splitIntoMap(resourceOperatedUpon);
     		
     		if (resourceOperatedUponMap.containsKey("service")) {
-    	
-    			String ticket = resourceOperatedUponMap.get("return");  		
+
+				String ticket = "";
+				/* key depends on CAS version :
+				 - cas<6.6.10 -> return
+				 - 6.6.9<cas<7.x -> ticket
+				 - 7.x<cas -> ticketId
+				 */
+				for(String ticketKeyFromCas: Arrays.asList("return", "ticket", "ticketId")) {
+					if(resourceOperatedUponMap.containsKey(ticketKeyFromCas)) {
+						ticket = resourceOperatedUponMap.get(ticketKeyFromCas);
+						break;
+					}
+				}
         		String service = resourceOperatedUponMap.get("service");  	
         		
         		ServletRequestAttributes sra = (ServletRequestAttributes)RequestContextHolder.getRequestAttributes();


### PR DESCRIPTION
Avec ce petit hack, on couvre toutes les versions de CAS, pour l'instant.

key depends on CAS version :
				 - cas<6.6.10 -> return
				 - 6.6.9<cas<7.x -> ticket
				 - 7.x<cas -> ticketId

Cf les commits suivants :
- pour la branche 6 : https://github.com/apereo/cas/commit/8395b20728cdad8ef3db376f82858094a0334857
- pour la branche master (future 7) : https://github.com/apereo/cas/commit/14269821e884e116d4ce947cc696c4e0fffe82d4#diff-fd6ae496c39218ddbd5073f7d19379c98c8ba825a9766c23537d374cc05f2d68